### PR TITLE
chore: do not run LibCal check daily

### DIFF
--- a/.github/workflows/check-libcal.yml
+++ b/.github/workflows/check-libcal.yml
@@ -4,11 +4,6 @@
 
 name: LibCal check
 
-on:
-  schedule:
-    # Run every day at 4:05 AM.
-    - cron: '5 4 * * *'
-
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
Only run when requested. We ignore the results anyway.